### PR TITLE
Fix broken quiz links

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -6,7 +6,7 @@ This lesson covers the basics of programming languages. The topics covered here 
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz
-[Pre-lecture quiz](1-getting-started-lessons/1-intro-to-programming-languages/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ## Introduction
 
@@ -181,7 +181,7 @@ When a developer wants to learn something new, they'll most likely turn to docum
 Compare some programming languages. What are some of the unique traits of JavaScript vs. Java? How about COBOL vs. Go?
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](1-getting-started-lessons/1-intro-to-programming-languages/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/1-getting-started-lessons/2-github-basics/README.md
+++ b/1-getting-started-lessons/2-github-basics/README.md
@@ -6,7 +6,7 @@ This lesson covers the basics of GitHub, a platform to host and manage changes t
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz
-[Pre-lecture quiz](1-getting-started-lessons/2-github-basics/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ## Introduction
 
@@ -274,7 +274,7 @@ Projects might also have discussion in forums, mailing lists, or chat channels l
 Pair with a friend to work on each other's code. Create a project collaboratively, fork code, create branches, and merge changes.
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](1-getting-started-lessons/2-github-basics/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/1-getting-started-lessons/3-accessibility/README.md
+++ b/1-getting-started-lessons/3-accessibility/README.md
@@ -4,7 +4,7 @@
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz
-[Pre-lecture quiz](1-getting-started-lessons/3-accessibility/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 > The power of the Web is in its universality. Access by everyone regardless of disability is an essential aspect.
 >
@@ -207,7 +207,7 @@ Take this HTML and rewrite it to be as accessible as possible, given the strateg
 ```
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](1-getting-started-lessons/3-accessibility/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/2-js-basics/1-data-types/README.md
+++ b/2-js-basics/1-data-types/README.md
@@ -4,7 +4,7 @@
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz
-[Pre-lecture quiz](2-js-basics/1-data-types/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 This lesson covers the basics of JavaScript, the language that provides interactivity on the web.
 
@@ -185,7 +185,7 @@ Booleans can be only two values: `true` or `false`. Booleans can help make decis
 JavaScript is notorious for its surprising ways of handling datatypes on occasion. Do a bit of research on these 'gotchas'. For example: case sensitivity can bite! Try this in your console: `let age = 1; let Age = 2; age == Age` (resolves `false` -- why?). What other gotchas can you find?
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](2-js-basics/1-data-types/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/2-js-basics/2-functions-methods/README.md
+++ b/2-js-basics/2-functions-methods/README.md
@@ -4,7 +4,7 @@
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz
-[Pre-lecture quiz](2-js-basics/2-functions-methods/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 When we think about writing code, we always want to ensure our code is readable. While this sounds counterintuitive, code is read many more times than it's written. One core tool in a developer's toolbox to ensure maintainable code is the **function**.
 
@@ -181,7 +181,7 @@ You've now seen we have three ways to pass a function as a parameter and might b
 Can you articulate in one sentence the difference between functions and methods? Give it a try!
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](2-js-basics/2-functions-methods/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/2-js-basics/3-making-decisions/README.md
+++ b/2-js-basics/3-making-decisions/README.md
@@ -5,7 +5,7 @@
 
 ## 
 Pre-Lecture Quiz
-[Pre-lecture quiz](2-js-basics/3-making-decisions/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 Making decisions and controlling the order in which your code runs makes your code reusable and robust. This section covers the syntax for controlling data flow in JavaScript and its significance when used with Boolean data types
 
@@ -162,7 +162,7 @@ Create a program that is written first with logical operators, and then rewrite 
 
 ## 
 Post-Lecture Quiz
-[Post-lecture quiz](2-js-basics/3-making-decisions/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/2-js-basics/4-arrays-loops/README.md
+++ b/2-js-basics/4-arrays-loops/README.md
@@ -5,7 +5,7 @@
 
 ## 
 Pre-Lecture Quiz
-[Pre-lecture quiz](2-js-basics/4-arrays-loops/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 This lesson covers the basics of JavaScript, the language that provides interactivity on the web. In this lesson, you'll learn about arrays and loops, which are used to manipulate data.
 
@@ -114,7 +114,7 @@ There are other ways of looping over arrays other than for and while loops. Ther
 
 ## 
 Post-Lecture Quiz
-[Post-lecture quiz](2-js-basics/4-arrays-loops/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 
 ## Review & Self Study

--- a/3-terrarium/1-intro-to-html/README.md
+++ b/3-terrarium/1-intro-to-html/README.md
@@ -5,7 +5,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](3-terrarium/1-intro-to-html/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -209,7 +209,7 @@ There are some wild 'older' tags in HTML that are still fun to play with, though
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](3-terrarium/1-intro-to-html/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/3-terrarium/2-intro-to-css/README.md
+++ b/3-terrarium/2-intro-to-css/README.md
@@ -5,7 +5,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](3-terrarium/2-intro-to-css.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -252,7 +252,7 @@ To complete the post-lecture quiz, go through this Learn module: [Style your HTM
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](3-terrarium/2-intro-to-css/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/3-terrarium/3-intro-to-DOM-and-closures/README.md
+++ b/3-terrarium/3-intro-to-DOM-and-closures/README.md
@@ -5,7 +5,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](3-terrarium/3-intro-to-DOM-and-closures/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -199,7 +199,7 @@ Add new event handler to your closure to do something more to the plants; for ex
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](3-terrarium/3-intro-to-DOM-and-closures/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/4-typing-game/typing-game/README.md
+++ b/4-typing-game/typing-game/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](4-typing-game/typing-game/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ## Event driven programming
 
@@ -325,7 +325,7 @@ Add more functionality
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](4-typing-game/typing-game/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/5-browser-extension/1-about-browsers/README.md
+++ b/5-browser-extension/1-about-browsers/README.md
@@ -5,7 +5,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](5-browser-extension/1-about-browsers/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -150,7 +150,7 @@ Take a look at a browser extension store and install one to your browser. You ca
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](5-browser-extension/1-about-browsers/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/5-browser-extension/2-forms-browsers-local-storage/README.md
+++ b/5-browser-extension/2-forms-browsers-local-storage/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](5-browser-extension/2-forms-browsers-local-storage/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -210,7 +210,7 @@ We've discussed several types of API so far in these lessons. Choose a web API a
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](5-browser-extension/2-forms-browsers-local-storage/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/5-browser-extension/3-background-tasks-and-performance/README.md
+++ b/5-browser-extension/3-background-tasks-and-performance/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](5-browser-extension/3-background-tasks-and-performance/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -147,7 +147,7 @@ Investigate some open source web sites have been around a long time ago, and, ba
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](5-browser-extension/3-background-tasks-and-performance/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/6-space-game/1-introduction/README.md
+++ b/6-space-game/1-introduction/README.md
@@ -4,7 +4,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/6-space-game/1-introduction/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Inheritance and Composition in game development
 
@@ -213,7 +213,7 @@ Think about how the pub-sub pattern can enhance a game. Which parts should emit 
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/6-space-game/1-introduction/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/6-space-game/2-drawing-to-canvas/README.md
+++ b/6-space-game/2-drawing-to-canvas/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/6-space-game/2-drawing-to-canvas/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ## The Canvas
 
@@ -205,7 +205,7 @@ You've learned about drawing with the 2D-focused Canvas API; take a look at the 
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/6-space-game/2-drawing-to-canvas/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/6-space-game/3-moving-elements-around/README.md
+++ b/6-space-game/3-moving-elements-around/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/6-space-game/3-moving-elements-around/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 Games aren't much fun until you have aliens running around on screen! In this game, we will make use of two types of movements:
 
@@ -377,7 +377,7 @@ As you can see, your code can turn into 'spaghetti code' when you start adding f
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/6-space-game/3-moving-elements-around/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/6-space-game/4-collision-detection/README.md
+++ b/6-space-game/4-collision-detection/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/6-space-game/4-collision-detection/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 In this lesson you will learn how to shoot lasers with JavaScript! We will add two things to our game:
 
@@ -286,7 +286,7 @@ Add an explosion! Take a look at the game assets in [the Space Art repo](../solu
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/6-space-game/4-collision-detection/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/6-space-game/5-keeping-score/README.md
+++ b/6-space-game/5-keeping-score/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/6-space-game/5-keeping-score/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 In this lesson, you'll learn how to add scoring to a game and calculate lives.
 
@@ -178,7 +178,7 @@ Your code is almost complete. Can you envision your next steps?
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/6-space-game/5-keeping-score/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/6-space-game/6-end-condition/README.md
+++ b/6-space-game/6-end-condition/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/6-space-game/6-end-condition/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 There are different ways to express and *end condition* in a game. It's up to you as the creator of the game to say why the game has ended. Here are some reasons, if we assume we are talking about the space game you have been building so far:
 
@@ -211,7 +211,7 @@ Add a sound! Can you add a sound to enhance your game play, maybe when there's a
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/6-space-game/6-end-condition/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/7-bank-project/1-template-route/README.md
+++ b/7-bank-project/1-template-route/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/7-bank-project/1-template-route/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -284,7 +284,7 @@ Add a new template and route for a third page that shows the credits for this ap
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/7-bank-project/1-template-route/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/7-bank-project/2-forms/README.md
+++ b/7-bank-project/2-forms/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/7-bank-project/2-forms/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -279,7 +279,7 @@ Here's an example of what the final login page can look like after a bit of styl
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/7-bank-project/2-forms/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Review & Self Study
 

--- a/7-bank-project/3-data/README.md
+++ b/7-bank-project/3-data/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/7-bank-project/3-data/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -319,7 +319,7 @@ Here's an example of a styled dashboard page:
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/7-bank-project/3-data/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Assignment
 

--- a/7-bank-project/4-state-management/README.md
+++ b/7-bank-project/4-state-management/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](/7-bank-project/4-state-management/.github/pre-lecture-quiz.md)
+[Pre-lecture quiz](.github/pre-lecture-quiz.md)
 
 ### Introduction
 
@@ -270,7 +270,7 @@ Try working together to change what is saved and loaded from `localStorage` to o
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](/7-bank-project/4-state-management/.github/post-lecture-quiz.md)
+[Post-lecture quiz](.github/post-lecture-quiz.md)
 
 ## Assignment
 


### PR DESCRIPTION
Pre/Post quizzes links were broken. As an example the URLs were like `1-getting-started-lessons/1-intro-to-programming-languages/.github/...`, but actually they must be like   `/.github/...`.