### PR TITLE
fix loadAsset function in 6-space-game/2-drawing-to-canvas/README.md

### DIFF
--- a/6-space-game/2-drawing-to-canvas/README.md
+++ b/6-space-game/2-drawing-to-canvas/README.md
@@ -81,14 +81,14 @@ img.onload = () => {
 It's recommended to wrap the above in a construct like so, so it's easier to use and you only try to manipulate it when it's fully loaded:
 
 ```javascript
-async function loadAsset(path) {
+function loadAsset(path) {
   return new Promise((resolve) => {
     const img = new Image();
     img.src = path;
     img.onload = () => {
       // image loaded and ready to be used
+      resolve(img);
     }
-    resolve(img);
   })
 }
 


### PR DESCRIPTION
Hi, I made a small fix in the example code of 6-space-game/2-drawing-to-canvas/README.md
The corresponding code in 6-space-game/2-drawing-to-canvas/solution/app.js looks fine.

1. move `resolve(img)` in loadAsset function to the inside of the img.onload function to resolve the promise after the image is loaded
2. remove the async keyword of loadAsset because it is not that harmful but not yet necessary