### PR TITLE
Link specifically to deprecated tags in intro to HTML

### DIFF
--- a/3-terrarium/1-intro-to-html/README.md
+++ b/3-terrarium/1-intro-to-html/README.md
@@ -213,7 +213,7 @@ Add this markup above the last `</div>` tag:
 
 ## 🚀Challenge
 
-There are some wild 'older' tags in HTML that are still fun to play with, though you shouldn't use deprecated tags such as [these tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element) in your markup. Still, can you use the old `<marquee>` tag to make the h1 title scroll horizontally? (if you do, don't forget to remove it afterwards)
+There are some wild 'older' tags in HTML that are still fun to play with, though you shouldn't use deprecated tags such as [these tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#Obsolete_and_deprecated_elements) in your markup. Still, can you use the old `<marquee>` tag to make the h1 title scroll horizontally? (if you do, don't forget to remove it afterwards)
 
 ## Post-Lecture Quiz
 


### PR DESCRIPTION
the link in "deprecated tags such as [these tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)" currently links to the list of all HTML elements with the deprecated and obsolete ones at the very bottom which is kinda confusing. This PR changes the link to go directly to the section on [obsolete and deprecated elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#Obsolete_and_deprecated_elements).