### PR TITLE
Change function's name to what is called in Javascript.

### DIFF
--- a/3-terrarium/3-intro-to-DOM-and-closures/README.md
+++ b/3-terrarium/3-intro-to-DOM-and-closures/README.md
@@ -176,7 +176,7 @@ All this recalculation of positioning allows you to fine-tune the behavior of th
 
 ### Task 
 
-The final task to complete the interface is to add the `closeElementDrag` function after the closing curly bracket of `elementDrag`:
+The final task to complete the interface is to add the `stopElementDrag` function after the closing curly bracket of `elementDrag`:
 
 ```javascript
 function stopElementDrag() {


### PR DESCRIPTION
Function's name in the instructions was "closeElementDrag", corrected it to "StopElementDrag", which is what it's called in the Javascript file.