### PR TITLE
Trivial: Enable relativePath conf in docsify

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
   <script>
     window.$docsify = {
       name: 'Web Development for Beginners: A Curriculum',
-      repo: 'https://github.com/microsoft/Web-Dev-For-Beginners'
+      repo: 'https://github.com/microsoft/Web-Dev-For-Beginners',
+      relativePath: true
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
This configuration solves "404 - Not found" issues browsing files
using "docsify serve" command for offline access.

See configuration details on docsify documentation:
- https://docsify.js.org/#/configuration?id=relativepath