### PR TITLE
Use markdown table format to display images instead

### DIFF
--- a/7-bank-project/README.md
+++ b/7-bank-project/README.md
@@ -2,7 +2,8 @@
 
 In this project, you'll learn how to build a fictional bank. These lessons include instructions on how to layout a web app and provide routes, build forms, manage state, and fetch data from an API from which you can fetch the bank's data.
 
-<img src="images/screen1.png" width="50%" height="auto"/><img src="images/screen2.png" width="50%" height="auto"/>
+| ![Screen1](images/screen1.png) | ![Screen2](images/screen2.png) |
+|--------------------------------|--------------------------------|
 
 ## Lessons
 

--- a/7-bank-project/translations/README.es.md
+++ b/7-bank-project/translations/README.es.md
@@ -2,7 +2,8 @@
 
 En este proyecto, aprenderá a construir un banco ficticio. Estas lecciones incluyen instrucciones sobre cómo diseñar un sitio web y proporcionar rutas, crear formularios, administrar el estado y obtener datos de una API desde la cual puede obtener los datos del banco.
 
-<img src="screen1.png" width="50%" height="auto"><img src="screen2.png" width="50%" height="auto">
+| ![Screen1](../images/screen1.png) | ![Screen2](../images/screen2.png) |
+|-----------------------------------|-----------------------------------|
 
 ## Lecciones
 

--- a/7-bank-project/translations/README.ko.md
+++ b/7-bank-project/translations/README.ko.md
@@ -2,7 +2,8 @@
 
 이 프로젝트에서는, 가상의 은행을 만드는 방법을 배웁니다. 이 강의에는 웹 앱을 레이아웃과 라우트를 제공하고, 폼을 작성하며 상태를 관리하고, 은행 데이터 API에서 데이터를 가져오는 방법에 대한 지침이 포함되어 있습니다.
 
-<img src="../images/screen1.png" width="50%" height="auto"/><img src="../images/screen2.png" width="50%" height="auto"/>
+| ![Screen1](../images/screen1.png) | ![Screen2](../images/screen2.png) |
+|-----------------------------------|-----------------------------------|
 
 ## 강의
 


### PR DESCRIPTION
Using "<img src />" HTML cannot guarantee relative paths.
The issue is being investigated but using a markdown table format
would be an alternative approach.

- FYI: https://github.com/docsifyjs/docsify/issues/850