### PR TITLE
fix empty locale option when first created (quiz-app)

### DIFF
--- a/quiz-app/src/App.vue
+++ b/quiz-app/src/App.vue
@@ -38,7 +38,9 @@ export default {
     },
   },
   created() {
-    this.locale = this.$route.query.loc;
+    if (this.$route.query.loc) {
+      this.locale = this.$route.query.loc;
+    }
   },
 };
 </script>


### PR DESCRIPTION
### AS-IS
When App component is created not using query parameter 'loc', locale data is '' (empty).

### TO-BE
Add checking logic $route.query.loc

### Reference
https://github.com/microsoft/Web-Dev-For-Beginners/pull/140#issuecomment-753474895