### PR TITLE
Fix laser cooldown bug

### DIFF
--- a/6-space-game/4-collision-detection/solution/app.js
+++ b/6-space-game/4-collision-detection/solution/app.js
@@ -60,8 +60,9 @@ class Hero extends GameObject {
 		let id = setInterval(() => {
 			if (this.cooldown > 0) {
 				this.cooldown -= 100;
-			} else {
-				clearInterval(id);
+				if(this.cooldown === 0) {
+					clearInterval(id);
+				}
 			}
 		}, 200);
 	}

--- a/6-space-game/5-keeping-score/solution/app.js
+++ b/6-space-game/5-keeping-score/solution/app.js
@@ -60,8 +60,9 @@ class Hero extends GameObject {
 		let id = setInterval(() => {
 			if (this.cooldown > 0) {
 				this.cooldown -= 100;
-			} else {
-				clearInterval(id);
+				if(this.cooldown === 0) {
+					clearInterval(id);
+				}
 			}
 		}, 200);
 	}

--- a/6-space-game/5-keeping-score/your-work/app.js
+++ b/6-space-game/5-keeping-score/your-work/app.js
@@ -58,8 +58,9 @@ class Hero extends GameObject {
 		let id = setInterval(() => {
 			if (this.cooldown > 0) {
 				this.cooldown -= 100;
-			} else {
-				clearInterval(id);
+				if(this.cooldown === 0) {
+					clearInterval(id);
+				}
 			}
 		}, 200);
 	}

--- a/6-space-game/6-end-condition/solution/app.js
+++ b/6-space-game/6-end-condition/solution/app.js
@@ -65,8 +65,9 @@ class Hero extends GameObject {
 		let id = setInterval(() => {
 			if (this.cooldown > 0) {
 				this.cooldown -= 100;
-			} else {
-				clearInterval(id);
+				if(this.cooldown === 0) {
+					clearInterval(id);
+				}
 			}
 		}, 200);
 	}

--- a/6-space-game/6-end-condition/your-work/app.js
+++ b/6-space-game/6-end-condition/your-work/app.js
@@ -60,8 +60,9 @@ class Hero extends GameObject {
 		let id = setInterval(() => {
 			if (this.cooldown > 0) {
 				this.cooldown -= 100;
-			} else {
-				clearInterval(id);
+				if(this.cooldown === 0) {
+					clearInterval(id);
+				}
 			}
 		}, 200);
 	}


### PR DESCRIPTION
I'm not sure if PRs like these are considered, but this fixes a minor laser cooldown bug that's already fixed in [6-space-game/solution/app.js](https://github.com/microsoft/Web-Dev-For-Beginners/blob/main/6-space-game/solution/app.js) (lines 307-309) but not in the lessons' individual app.js files.

**Describe the bug**
Pressing space bar before the laser's cooldown is over will result in the cooldown being nullified, letting the ship shoot much faster than the cooldown should allow.

**To Reproduce**
1. Open 'index.html'
2. Press space bar very quickly

**Screenshot**
[Result of quickly pressing space bar](https://i.imgur.com/ofGVwy9.png)
(intended cooldown is 1200 ms)