### PR TITLE
Fix Markdown translation links in js-basics lesson

### DIFF
--- a/2-js-basics/4-arrays-loops/README.md
+++ b/2-js-basics/4-arrays-loops/README.md
@@ -113,7 +113,7 @@ for (let i = 0; i < iceCreamFlavors.length; i++) {
 There are other ways of looping over arrays other than for and while loops. There are [forEach](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach), [for-of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), and [map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map). Rewrite your array loop using one of these techniques.
 
 ## Post-Lecture Quiz
-[Pre-lecture quiz](https://nice-beach-0fe9e9d0f.azurestaticapps.net/quiz/14)
+[Post-lecture quiz](https://nice-beach-0fe9e9d0f.azurestaticapps.net/quiz/14)
 
 
 ## Review & Self Study

--- a/2-js-basics/translations/README.de.md
+++ b/2-js-basics/translations/README.de.md
@@ -4,10 +4,10 @@ JavaScript ist die Sprache des Webs. In diesen vier Lektionen lernen Sie die Gru
 
 ### Themen
 
-1. [Variablen und Datentypen](1-Datentypen/README.md)
-2. [Funktionen und Methoden](2-functions-methods/README.md)
-3. [Entscheidungen mit JavaScript treffen](3-making-decisions/README.md)
-4. [Arrays und Loops](4-arrays-loops/README.md)
+1. [Variablen und Datentypen](../1-data-types/translations/README.de.md)
+2. [Funktionen und Methoden](../2-functions-methods/translations/README.de.md)
+3. [Entscheidungen mit JavaScript treffen](../3-making-decisions/translations/README.de.md)
+4. [Arrays und Loops](../4-arrays-loops/translations/README.de.md)
 
 ### Credits
 

--- a/2-js-basics/translations/README.es.md
+++ b/2-js-basics/translations/README.es.md
@@ -4,10 +4,10 @@ JavaScript es el lenguaje de la web. En estas cuatro lecciones, aprenderá sus c
 
 ### Temas
 
-1. [Variables y tipos de datos](data-types/README.md)
-2. [Funciones y métodos](variables-datatypes/README.md)
-3. [Toma de decisiones con JavaScript](making-decisions/README.md)
-4. [Arrays and Loops](arrays-loops/README.md)
+1. [Variables y tipos de datos](../1-data-types/translations/README.es.md)
+2. [Funciones y métodos](../2-functions-methods/translations/README.es.md)
+3. [Toma de decisiones con JavaScript](../3-making-decisions/translations/README.es.md)
+4. [Arrays and Loops](../4-arrays-loops/translations/README.es.md)
 
 ### Créditos
 

--- a/2-js-basics/translations/README.it.md
+++ b/2-js-basics/translations/README.it.md
@@ -4,10 +4,10 @@ JavaScript è il linguaggio del web. In queste quattro lezioni, si impareranno l
 
 ### Argomenti
 
-1. [Variabili e Tipi di Dato](1-data-types/translations/README.it.md)
-2. [Funzioni e Metodi](2-functions-methods/translations/README.it.md)
-3. [Prendere Decisioni con JavaScript](3-making-decisions/translations/README.it.md)
-4. [Array e Cicli](4-arrays-loops/translations/README.it.md)
+1. [Variabili e Tipi di Dato](../1-data-types/translations/README.it.md)
+2. [Funzioni e Metodi](../2-functions-methods/translations/README.it.md)
+3. [Prendere Decisioni con JavaScript](../3-making-decisions/translations/README.it.md)
+4. [Array e Cicli](../4-arrays-loops/translations/README.it.md)
 
 ### Crediti
 

--- a/2-js-basics/translations/README.ja.md
+++ b/2-js-basics/translations/README.ja.md
@@ -4,10 +4,10 @@ JavaScript は Web の言語です。この4つのレッスンでは、その基
 
 ### トピック
 
-1. [変数とデータ型](1-data-types/README.md)
-2. [関数とメソッド](2-functions-methods/README.md)
-3. [JavaScript での意思決定](3-making-decisions/README.md)
-4. [配列とループ](4-arrays-loops/README.md)
+1. [変数とデータ型](../1-data-types/translations/README.ja.md)
+2. [関数とメソッド](../2-functions-methods/translations/README.ja.md)
+3. [JavaScript での意思決定](../3-making-decisions/translations/README.ja.md)
+4. [配列とループ](../4-arrays-loops/translations/README.ja.md)
 
 ### Credits
 

--- a/2-js-basics/translations/README.ms.md
+++ b/2-js-basics/translations/README.ms.md
@@ -4,10 +4,10 @@ JavaScript adalah bahasa web. Dalam empat pelajaran ini, anda akan mengetahui as
 
 ### Topik
 
-1. [Pemboleh ubah dan Jenis Data](1-data-types/README.md)
-2. [Fungsi dan Kaedah](2-functions-methods/README.md)
-3. [Membuat Keputusan dengan JavaScript](3-making-decisions/README.md)
-4. [Susunan dan Gelung](4-arrays-loops/README.md)
+1. [Pemboleh ubah dan Jenis Data](../1-data-types/translations/README.ms.md)
+2. [Fungsi dan Kaedah](../2-functions-methods/translations/README.ms.md)
+3. [Membuat Keputusan dengan JavaScript](../3-making-decisions/translations/README.ms.md)
+4. [Susunan dan Gelung](../4-arrays-loops/translations/README.ms.md)
 
 ### Kredit
 


### PR DESCRIPTION
Links appeared to be broken. It looks like translations are still a work in progress throughout so I only fixed a couple that I noticed while going through the js-basics lesson.