### PR TITLE
Disable deployment on PR

### DIFF
--- a/.github/workflows/azure-static-web-apps-nice-beach-0fe9e9d0f.yml
+++ b/.github/workflows/azure-static-web-apps-nice-beach-0fe9e9d0f.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
+#   pull_request:
+#     types: [opened, synchronize, reopened, closed]
+#     branches:
+#       - main
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
Disable PR deployment as it's in error for all external PRs (will still work on main branches commits or merges)