### PR TITLE
Fix to list all existing locales in quiz app header

### DIFF
--- a/quiz-app/src/App.vue
+++ b/quiz-app/src/App.vue
@@ -4,19 +4,7 @@
       <router-link class="navlink" to="/">Home</router-link>
       <label for="locale">locale</label>
       <select v-model="locale">
-        <option>en</option>
-        <option>es</option>
-        <option>fr</option>
-        <option>gr</option>
-        <option>hi</option>
-        <option>id</option>
-        <option>it</option>
-        <option>ko</option>
-        <option>ms</option>
-        <option>nl</option>
-        <option>zh_cn</option>
-        <option>zh_tw</option>
-
+        <option v-for="localeName in availableLocales" :key="localeName">{{ localeName }}</option>
       </select>
     </nav>
     <div id="app">
@@ -41,6 +29,7 @@ export default {
   data() {
     return {
       locale: "en",
+      availableLocales: Object.keys(messages).sort(),
     };
   },
   watch: {


### PR DESCRIPTION
When I click the 「事後確認」 link in the Japanese README ( https://github.com/microsoft/Web-Dev-For-Beginners/blob/main/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.ja.md ), the locale selection field is blank as shown in the screenshot below.
![image](https://user-images.githubusercontent.com/291184/137303180-32d1c9c1-bc30-4373-9bf1-6444c1e4a216.png)

To fix this problem, changed manual listing to listing all existing locales automatically.

