### PR TITLE
Add git branch -M main

### DIFF
--- a/1-getting-started-lessons/2-github-basics/README.md
+++ b/1-getting-started-lessons/2-github-basics/README.md
@@ -128,6 +128,7 @@ Let's say you have a folder locally with some code project and you want to start
    > Note, before you type the command go to your GitHub repo page to find the repository URL. You will use it in the below command. Replace `repository_name` with your GitHub URL.
 
    ```bash
+   git branch -M main
    git remote add origin https://github.com/username/repository_name.git
    ```
 


### PR DESCRIPTION
In the [_Github basics_ lesson](https://github.com/microsoft/Web-Dev-For-Beginners/tree/main/1-getting-started-lessons/2-github-basics),  there is a step missing between steps 10 and 11. This is because the default branch name for new repositories is now _main_.
We need to include an additional step instructing the users to run ```git branch -M main```

Close #508 