### PR TITLE
Editing the git switch quiz answers and Readme.

### DIFF
--- a/1-getting-started-lessons/2-github-basics/README.md
+++ b/1-getting-started-lessons/2-github-basics/README.md
@@ -219,6 +219,7 @@ Let's go through a contributor workflow. Assume the contributor has already _for
    ```bash
    git switch [branch-name]
    ```
+   Another common way to switch branches is using the command `git checkout [branch-name]`.
 
 1. **Do work**. At this point you want to add your changes. Don't forget to tell Git about it with the following commands:
 

--- a/quiz-app/src/assets/translations/en.json
+++ b/quiz-app/src/assets/translations/en.json
@@ -209,11 +209,11 @@
 						"questionText": "How do you switch to a branch?",
 						"answerOptions": [
 							{
-								"answerText": "git checkout [branch-name]",
+								"answerText": "git fetch [branch-name]",
 								"isCorrect": "false"
 							},
 							{
-								"answerText": "git switch [branch-name]",
+								"answerText": "git switch [branch-name] OR git checkout [branch-name]",
 								"isCorrect": "true"
 							},
 							{


### PR DESCRIPTION
Git allows switching branches with either the experimental 'switch' command or the 'checkout' command. Currently when taking the Post Lesson quiz, the third question in the [Post Lecture quiz ](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/4) asks "How do you switch to a branch". The quiz answers are 'git checkout' 'git switch' or 'git load'. If the user chooses checkout they are told the answer is incorrect, however both checkout and switch are commonly used commands to "switch" branches in Git. I edited the answers to be 'git fetch', 'git checkout OR git switch', and 'git load'. Additionally I added a comment in the lesson README.md that explains that checkout is also commonly used to switch branches in Git. Thank you for considering this change.