### PR TITLE
added null as primitive type

### DIFF
--- a/2-js-basics/1-data-types/README.md
+++ b/2-js-basics/1-data-types/README.md
@@ -107,7 +107,7 @@ Constants are similar to variables, with two exceptions:
 
 Variables can store many different types of values, like numbers and text. These various types of values are known as the **data type**. Data types are an important part of software development because it helps developers make decisions on how the code should be written and how the software should run. Furthermore, some data types have unique features that help transform or extract additional information in a value.
 
-✅ Data Types are also referred to as JavaScript data primitives, as they are the lowest-level data types that are provided by the language. There are 6 primitive data types: string, number, bigint, boolean, undefined, and symbol. Take a minute to visualize what each of these primitives might represent. What is a `zebra`? How about `0`? `true`?
+✅ Data Types are also referred to as JavaScript data primitives, as they are the lowest-level data types that are provided by the language. There are 7 primitive data types: string, number, bigint, boolean, undefined, null and symbol. Take a minute to visualize what each of these primitives might represent. What is a `zebra`? How about `0`? `true`?
 
 ### Numbers
 


### PR DESCRIPTION
Hello.
I wonder if `null` should be added as a primitive type.
According to the Javascript [Specification](https://tc39.es/ecma262/#sec-null-value):
```
null is a primitive value that represents the intentional absence of any object value
```

This PR was created within Hacktoberfest. thx