### PR TITLE
Fix links to topics in the correct language

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
@@ -193,4 +193,3 @@ Estudia un poco sobre los diferentes lenguajes disponibles para programar. Inten
 
 ## [Tarea](../../assignment.es.md)
 
-[Leer la Documentación](assignment.es.md)

--- a/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
@@ -5,7 +5,9 @@ Esta lección cubre los conceptos básicos de los lenguajes de programación. Lo
 ![Intro Programming](/sketchnotes/webdev101-programming.png)
 > Dibujo por [Tomomi Imura](https://twitter.com/girlie_mac)
 
-## [Cuestionario](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/1)
+## Cuestionario Previo a la Clase
+[Cuestionario previo a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/1)
+
 ### Introducción
 
 En esta lección, cubriremos:
@@ -19,7 +21,6 @@ En esta lección, cubriremos:
 
 La programación (también conocida como codificación) es el proceso de escribir instrucciones en un dispositivo, como una computadora o un celular. Escribimos estas instrucciones con un lenguaje de programación, que luego es interpretado por el dispositivo. Este conjuntos de instrucciones pueden tener varios nombres, como *programa*, *programa de computadora*, *aplicación (app)* o *ejecutable* son algunos de los más populares.
 
-
 Un *programa* puede ser cualquier cosa que esté escrita con código; los sitios web, los videojuegos y las aplicaciones de teléfono son programas. Si bien es posible crear un programa sin escribir código, la lógica subyacente se interpreta al dispositivo y esa lógica probablemente se escribió con código. Un programa que está *ejecutándose* o *ejecutando código*, está ejecutando una serie de instrucciones. El dispositivo con el que estás leyendo esta lección está ejecutando un programa para imprimirlo en tu pantalla.
 
 ✅ Investigue un poco: ¿quién se considera el primer programador(a) de computadoras del mundo?
@@ -30,7 +31,7 @@ Los lenguajes de programación tienen un propósito principal: que los desarroll
 
 Los lenguajes de programación vienen en diferentes formatos y tienen diferentes propósitos. Por ejemplo, JavaScript se usa principalmente para aplicaciones web, mientras que Bash se usa principalmente para sistemas operativos.
 
-*Los idiomas de bajo nivel* normalmente requieren menos pasos que los *idiomas de alto nivel* para que un dispositivo interprete las instrucciones. Sin embargo, lo que hace que los lenguajes de alto nivel sean populares es su legibilidad y soporte. JavaScript es considerado un lenguaje de alto nivel.
+*Los lenguajes de bajo nivel* normalmente requieren menos pasos que los *lenguajes de alto nivel* para que un dispositivo interprete las instrucciones. Sin embargo, lo que hace que los lenguajes de alto nivel sean populares es su legibilidad y soporte. JavaScript es considerado un lenguaje de alto nivel.
 
 El siguiente código ilustra la diferencia entre un lenguaje de alto nivel con JavaScript y un lenguaje de bajo nivel con código Assembly ARM.
 
@@ -178,14 +179,19 @@ Cuando un desarrollador quiere aprender algo nuevo, lo más probable es que recu
 
 ✅ Investiga un poco: ahora que conoces los conceptos básicos del entorno de un desarrollador web, compáralo y contrasta con el entorno de un diseñador web.
 
+---
+
 ## 🚀 Reto
 
 Compara algunos lenguajes de programación. ¿Cuáles son algunos de los rasgos únicos de JavaScript frente a Java? ¿Qué hay de COBOL vs. Go?
 
-## [Prueba Post-lectura](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
+## Cuestionario Posterior a la Clase
+[Cuestionario posterior a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
 
-## Revisión y autoestudio
+## Revisión y Autoestudio
 
 Estudia un poco sobre los diferentes lenguajes disponibles para programar. Intenta escribir una línea en un lenguaje y luego vuelve a hacerlo en otros dos. ¿Qué aprendiste?
 
-**Tarea**: [Tarea](../assignment.md)
+## Asignación
+
+[Leer la Documentación](assignment.es.md)

--- a/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
@@ -191,6 +191,6 @@ Compara algunos lenguajes de programación. ¿Cuáles son algunos de los rasgos 
 
 Estudia un poco sobre los diferentes lenguajes disponibles para programar. Intenta escribir una línea en un lenguaje y luego vuelve a hacerlo en otros dos. ¿Qué aprendiste?
 
-## Asignación
+## [Tarea](../../assignment.es.md)
 
 [Leer la Documentación](assignment.es.md)

--- a/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
@@ -191,5 +191,5 @@ Compara algunos lenguajes de programación. ¿Cuáles son algunos de los rasgos 
 
 Estudia un poco sobre los diferentes lenguajes disponibles para programar. Intenta escribir una línea en un lenguaje y luego vuelve a hacerlo en otros dos. ¿Qué aprendiste?
 
-## [Tarea](../../assignment.es.md)
+## [Tarea](./assignment.es.md)
 

--- a/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
@@ -185,7 +185,7 @@ Cuando un desarrollador quiere aprender algo nuevo, lo más probable es que recu
 
 Compara algunos lenguajes de programación. ¿Cuáles son algunos de los rasgos únicos de JavaScript frente a Java? ¿Qué hay de COBOL vs. Go?
 
-## Cuestionario Posterior a la Clase
+## [Cuestionario Posterior a la Clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
 
 ## Revisión y Autoestudio
 

--- a/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.es.md
@@ -186,7 +186,6 @@ Cuando un desarrollador quiere aprender algo nuevo, lo más probable es que recu
 Compara algunos lenguajes de programación. ¿Cuáles son algunos de los rasgos únicos de JavaScript frente a Java? ¿Qué hay de COBOL vs. Go?
 
 ## Cuestionario Posterior a la Clase
-[Cuestionario posterior a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
 
 ## Revisión y Autoestudio
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -47,7 +47,7 @@ Digamos que tienes una directorio local con algún proyecto de código y deseas 
 
 > Revisa este video
 > 
-> [![Git and GitHub basics video](https://img.youtube.com/vi/9R31OUPpxU4/0.jpg)](https://www.youtube.com/watch?v=9R31OUPpxU4)
+> [![Video de los conceptos básicos de Git y GitHub](https://img.youtube.com/vi/9R31OUPpxU4/0.jpg)](https://www.youtube.com/watch?v=9R31OUPpxU4)
 
 1. **Crear repositorio en GitHub**. En GitHub.com, en la pestaña de repositorios, o en la barra de navegación superior derecha, busca el botón **nuevo repositorio**.
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -305,7 +305,7 @@ Los proyectos también pueden tener discusiones en foros, listas de correo o can
 
 ## 🚀 Reto
 
-Emparéjese con un amigo para trabajar en el código del otro. Cree un proyecto en colaboración, bifurque el código, cree ramas y fusione los cambios.
+Reúnete con un amigo para trabajar en el código del otro. Crea un proyecto en colaboración, haz fork del código, crea ramas y hagan merge a los cambios.
 
 ## Cuestionario Posterior a la Clase
 [Cuestionario posterior a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/4)

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -5,7 +5,8 @@ Esta lección cubre los conceptos básicos de GitHub, una plataforma para alojar
 ![Introducción a GitHub](/sketchnotes/webdev101-github.png)
 > Dibujo de [Tomomi Imura](https://twitter.com/girlie_mac)
 
-## [Cuestionario](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/3)
+## Cuestionario Previo a la Clase
+[Cuestionario previo a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/3)
 
 ### Introducción
 
@@ -44,6 +45,10 @@ Necesitarás un directorio con un proyecto de código en tu máquina local (comp
 Digamos que tienes una directorio local con algún proyecto de código y deseas rastrear tu progreso usando git (sistema de control de versiones). Algunas personas comparan el uso de git con escribir una carta de amor a tu futuro. Al leer tus mensajes de confirmación días, semanas o meses después, podrás recordar por qué tomaste una decisión o "revertiste" un cambio, siempre y cuando escribas buenos mensajes a la hora de enviar un commit.
 
 ### Tarea: Hacer un repositorio git y enviar código
+
+> Revisa este video
+> 
+> [![Git and GitHub basics video](https://img.youtube.com/vi/9R31OUPpxU4/0.jpg)](https://www.youtube.com/watch?v=9R31OUPpxU4)
 
 1. **Crear repositorio en GitHub**. En GitHub.com, en la pestaña de repositorios, o en la barra de navegación superior derecha, busca el botón **nuevo repositorio**.
 
@@ -151,7 +156,7 @@ Digamos que tienes una directorio local con algún proyecto de código y deseas 
    git push
    ```
 
-   > Sugerencia: es posible que también desees adoptar un archivo `.gitignore` para evitar que los archivos que no deseas rastrear aparezcan en GitHub. Puedes encontrar plantillas para archivos `.gitignore` en [.gitignore templates](github.com/github/gitignore).
+   > Sugerencia: es posible que también desees adoptar un archivo `.gitignore` para evitar que los archivos que no deseas rastrear aparezcan en GitHub. Puedes encontrar plantillas para archivos `.gitignore` en [.gitignore templates](https://github.com/github/gitignore).
 
 
 #### Confirmar mensajes
@@ -165,10 +170,13 @@ Como en el asunto, en el cuerpo (opcional) también use el presente imperativo. 
 
 ### Tarea: Colaborar
 
-
 La razón principal para poner cosas en GitHub fue hacer posible la colaboración con otros desarrolladores.
 
 ## Trabajando en proyectos con otros
+
+> Revisa este video
+>
+> [![Git and GitHub basics video](https://img.youtube.com/vi/bFCM-PC3cu8/0.jpg)](https://www.youtube.com/watch?v=bFCM-PC3cu8)
 
 En tu repositorio, ve a `Insights > Community` para ver cómo se compara tu proyecto con los estándares comunitarios recomendados.
 
@@ -270,6 +278,8 @@ Primero, busquemos un repositorio en GitHub que te interese y al que te gustarí
 
 ✅ Una buena forma de encontrar repositorios 'aptos para principiantes' es [buscar por la etiqueta `good-first-issue`](https://github.blog/2020-01-22-browse-good-first-issues-para-empezar-a-contribuir-al-código-abierto/).
 
+![Copy a repo locally](../images/clone_repo.png)
+
 Hay varias formas de copiar código. Una forma es "clonar" el contenido del repositorio, usando HTTPS, SSH o usando GitHub CLI (Interfaz de línea de comandos).
 
 Abre tu terminal y clona el repositorio así:
@@ -284,7 +294,7 @@ Por último, puedes descargar el código en un directorio comprimido.
 
 ### Algunas cosas más interesantes sobre GitHub
 
-Puede destacar, ver y / o "fork" cualquier repositorio público en GitHub. Puedes encontrar tus repositorios destacados en el menú desplegable de la parte superior derecha. Es como marcar como favorito, pero por código.
+Puede destacar, ver y/o "fork" cualquier repositorio público en GitHub. Puedes encontrar tus repositorios destacados en el menú desplegable de la parte superior derecha. Es como marcar como favorito, pero por código.
 
 Los proyectos tienen un rastreador de problemas, principalmente en GitHub en la pestaña "Issues" a menos que se indique lo contrario, donde las personas debaten los problemas relacionados con el proyecto. Y la pestaña Pull requests es donde las personas debaten y revisan los cambios que están en curso.
 
@@ -292,20 +302,27 @@ Los proyectos también pueden tener discusiones en foros, listas de correo o can
 
 ✅ Echa un vistazo a tu nuevo repositorio de GitHub y prueba algunas cosas, como editar la configuración, agregar información a tu repositorio y crear un proyecto (como un tablero Kanban). ¡Hay muchas cosas que puedes hacer!
 
-🚀 Desafío: Haz pareja con un amigo(a) para trabajar juntos en el código. Crea un proyecto de forma colaborativa, haz fork del proyecto, crea ramas y combina los cambios.
+---
 
-## [Post-lecture prueba](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/4)
+## 🚀 Reto
 
-## Revisión y autoestudio
+Emparéjese con un amigo para trabajar en el código del otro. Cree un proyecto en colaboración, bifurque el código, cree ramas y fusione los cambios.
+
+## Cuestionario Posterior a la Clase
+[Cuestionario posterior a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/4)
+
+## Revisión y Autoestudio
 
 Obtén más información sobre [contribución al software de código abierto](https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution).
 
 [Hoja de referencia de Git](https://training.github.com/downloads/github-git-cheat-sheet/).
 
-Práctica práctica práctica. GitHub tiene excelentes rutas de aprendizaje disponibles a través de [lab.github.com](https://lab.github.com/):
+Practica, practica, practica. GitHub tiene excelentes rutas de aprendizaje disponibles a través de [lab.github.com](https://lab.github.com/):
 
 - [Primera semana en GitHub](https://lab.github.com/githubtraining/first-week-on-github)
 
 También encontrarás laboratorios más avanzados.
 
-**Tarea**: Completa [la primera semana en el laboratorio de capacitación de GitHub](https://lab.github.com/githubtraining/first-week-on-github)
+## Asignación
+
+Completa [La Primera Semana en el Laboratorio de capacitación de GitHub](https://lab.github.com/githubtraining/first-week-on-github)

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -6,7 +6,6 @@ Esta lección cubre los conceptos básicos de GitHub, una plataforma para alojar
 > Dibujo de [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Cuestionario Previo a la Clase
-[Cuestionario previo a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/3)
 
 ### Introducción
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -322,6 +322,6 @@ Practica, practica, practica. GitHub tiene excelentes rutas de aprendizaje dispo
 
 También encontrarás laboratorios más avanzados.
 
-## Asignación
+## Tarea
 
 Completa [La Primera Semana en el Laboratorio de capacitación de GitHub](https://lab.github.com/githubtraining/first-week-on-github)

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -308,7 +308,6 @@ Los proyectos también pueden tener discusiones en foros, listas de correo o can
 Reúnete con un amigo para trabajar en el código del otro. Crea un proyecto en colaboración, haz fork del código, crea ramas y hagan merge a los cambios.
 
 ## Cuestionario Posterior a la Clase
-[Cuestionario posterior a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/4)
 
 ## Revisión y Autoestudio
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -293,7 +293,7 @@ Por último, puedes descargar el código en un directorio comprimido.
 
 ### Algunas cosas más interesantes sobre GitHub
 
-Puede destacar, ver y/o "fork" cualquier repositorio público en GitHub. Puedes encontrar tus repositorios destacados en el menú desplegable de la parte superior derecha. Es como marcar como favorito, pero por código.
+Puedes destacar, ver y/o hacer "fork" cualquier repositorio público en GitHub. Asimismo, encontrar tus repositorios destacados en el menú desplegable de la parte superior derecha. Es como marcar como favorito, pero por código.
 
 Los proyectos tienen un rastreador de problemas, principalmente en GitHub en la pestaña "Issues" a menos que se indique lo contrario, donde las personas debaten los problemas relacionados con el proyecto. Y la pestaña Pull requests es donde las personas debaten y revisan los cambios que están en curso.
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -277,7 +277,7 @@ Primero, busquemos un repositorio en GitHub que te interese y al que te gustarí
 
 ✅ Una buena forma de encontrar repositorios 'aptos para principiantes' es [buscar por la etiqueta `good-first-issue`](https://github.blog/2020-01-22-browse-good-first-issues-para-empezar-a-contribuir-al-código-abierto/).
 
-![Copy a repo locally](../images/clone_repo.png)
+![Copia un repositorio localmente](../images/clone_repo.png)
 
 Hay varias formas de copiar código. Una forma es "clonar" el contenido del repositorio, usando HTTPS, SSH o usando GitHub CLI (Interfaz de línea de comandos).
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -5,7 +5,7 @@ Esta lección cubre los conceptos básicos de GitHub, una plataforma para alojar
 ![Introducción a GitHub](/sketchnotes/webdev101-github.png)
 > Dibujo de [Tomomi Imura](https://twitter.com/girlie_mac)
 
-## Cuestionario Previo a la Clase
+## [Cuestionario previo a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/3)
 
 ### Introducción
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -307,7 +307,7 @@ Los proyectos también pueden tener discusiones en foros, listas de correo o can
 
 Reúnete con un amigo para trabajar en el código del otro. Crea un proyecto en colaboración, haz fork del código, crea ramas y hagan merge a los cambios.
 
-## Cuestionario Posterior a la Clase
+## [Cuestionario posterior a la clase](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/4)
 
 ## Revisión y Autoestudio
 

--- a/1-getting-started-lessons/2-github-basics/translations/README.es.md
+++ b/1-getting-started-lessons/2-github-basics/translations/README.es.md
@@ -175,7 +175,7 @@ La razón principal para poner cosas en GitHub fue hacer posible la colaboració
 
 > Revisa este video
 >
-> [![Git and GitHub basics video](https://img.youtube.com/vi/bFCM-PC3cu8/0.jpg)](https://www.youtube.com/watch?v=bFCM-PC3cu8)
+> [![Video de los conceptos básicos de Git y GitHub](https://img.youtube.com/vi/bFCM-PC3cu8/0.jpg)](https://www.youtube.com/watch?v=bFCM-PC3cu8)
 
 En tu repositorio, ve a `Insights > Community` para ver cómo se compara tu proyecto con los estándares comunitarios recomendados.
 

--- a/1-getting-started-lessons/translations/README.es.md
+++ b/1-getting-started-lessons/translations/README.es.md
@@ -4,9 +4,9 @@ En esta sección del plan de estudios, se te presentarán conceptos importantes 
 
 ### Temas
 
-1. [Introducción a los lenguajes de programación y herramientas del oficio](../1-intro-to-programming-languages/README.md)
-2. [Introducción a GitHub](../2-github-basics/README.md)
-3. [Conceptos básicos de Accesibilidad](../3-accessibility/README.md)
+1. [Introducción a los lenguajes de programación y herramientas del oficio](../1-intro-to-programming-languages/translations/README.es.md)
+2. [Introducción a GitHub](../2-github-basics/translations/README.es.md)
+3. [Conceptos básicos de Accesibilidad](../3-accessibility/translations/README.es.md)
 
 ### Créditos
 


### PR DESCRIPTION
There are three links in the README.es that lead to the English version. With this update, they now redirect to the Spanish version.