### PR TITLE
fix calculateColor function

### DIFF
--- a/5-browser-extension/3-background-tasks-and-performance/README.md
+++ b/5-browser-extension/3-background-tasks-and-performance/README.md
@@ -65,11 +65,11 @@ function calculateColor(value) {
 	let co2Scale = [0, 150, 600, 750, 800];
 	let colors = ['#2AA364', '#F5EB4D', '#9E4229', '#381D02', '#381D02'];
 
-	let closestNum = co2Scale.sort((a, b) => {
+	let closestNum = co2Scale.slice().sort((a, b) => {
 		return Math.abs(a - value) - Math.abs(b - value);
 	})[0];
 	console.log(value + ' is closest to ' + closestNum);
-	let num = (element) => element > closestNum;
+	let num = (element) => element === closestNum;
 	let scaleIndex = co2Scale.findIndex(num);
 
 	let closestColor = colors[scaleIndex];


### PR DESCRIPTION
Fix sorting **co2Scale** to not be in place, change finding **scaleIndex** to be equal to **closestNum** (not greater than).

Previously **co2Scale** was sorted in place and **scaleIndex** was taken for a value greater than **closestNum** (if one existed, otherwise it would return -1). 
After the changes, **scaleIndex** should correctly get the exact index of the **closestNum** value in **co2Scale**. 

Probably also requires the same changes to _Web-Dev-For-Beginners/5-browser-extension/solution/_ and _Web-Dev-For-Beginners/5-browser-extension/3-background-tasks-and-performance/translations/_.