### PR TITLE
fix: wrong image url in intro to programming README.zh-cz

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.zh-cn.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/translations/README.zh-cn.md
@@ -2,7 +2,7 @@
 
 这节课涵盖了编程语言的基础知识，涉及到的内容适用于如今大多数现代编程语言。在“工具介绍”部分，你会了解到一些对开发者很有用的软件。
 
-![Intro Programming](/sketchnotes/webdev101-programming.png)
+![Intro Programming](../../../sketchnotes/webdev101-programming.png)
 > 涂鸦笔记作者：[Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## 课前小测


### PR DESCRIPTION
# Description
wrong image URL in intro to programming README.zh-cz
before
![before](https://github.com/microsoft/Web-Dev-For-Beginners/assets/104900720/4f77623b-7f0b-4610-90c0-23fef4a4473e)
after
![after](https://github.com/microsoft/Web-Dev-For-Beginners/assets/104900720/074a46aa-35f2-4469-aa69-1b9eb1b10983)

Fixes #1184 

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
