### PR TITLE
Fix Typo: added a space in "making-decisions" README file

### DIFF
--- a/2-js-basics/3-making-decisions/README.md
+++ b/2-js-basics/3-making-decisions/README.md
@@ -1,9 +1,11 @@
 # JavaScript Basics: Making Decisions
 
 ![JavaScript Basics - Making decisions](../../sketchnotes/webdev101-js-decisions.png)
+
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz
+
 [Pre-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/11)
 
 Making decisions and controlling the order in which your code runs makes your code reusable and robust. This section covers the syntax for controlling data flow in JavaScript and its significance when used with Boolean data types
@@ -13,6 +15,7 @@ Making decisions and controlling the order in which your code runs makes your co
 > 🎥 Click the image above for a video about making decisions.
 
 > You can take this lesson on [Microsoft Learn](https://docs.microsoft.com/learn/modules/web-development-101-if-else/?WT.mc_id=academic-77807-sagibbon)!
+
 ## A Brief Recap on Booleans
 
 Booleans can be only two values: `true` or `false`. Booleans help make decisions on which lines of code should run when certain conditions are met.
@@ -44,8 +47,8 @@ Operators are used to evaluate conditions by making comparisons that will create
 The if statement will run code in between its blocks if the condition is true.
 
 ```javascript
-if (condition){
-    //Condition is true. Code in this block will run.
+if (condition) {
+  //Condition is true. Code in this block will run.
 }
 ```
 
@@ -55,9 +58,9 @@ Logical operators are often used to form the condition.
 let currentMoney;
 let laptopPrice;
 
-if (currentMoney >= laptopPrice){
-    //Condition is true. Code in this block will run.
-    console.log("Getting a new laptop!");
+if (currentMoney >= laptopPrice) {
+  //Condition is true. Code in this block will run.
+  console.log("Getting a new laptop!");
 }
 ```
 
@@ -69,25 +72,23 @@ The `else` statement will run the code in between its blocks when the condition 
 let currentMoney;
 let laptopPrice;
 
-if (currentMoney >= laptopPrice){
-    //Condition is true. Code in this block will run.
-    console.log("Getting a new laptop!");
-}
-else{
-    //Condition is false. Code in this block will run.
-    console.log("Can't afford a new laptop, yet!");
+if (currentMoney >= laptopPrice) {
+  //Condition is true. Code in this block will run.
+  console.log("Getting a new laptop!");
+} else {
+  //Condition is false. Code in this block will run.
+  console.log("Can't afford a new laptop, yet!");
 }
 ```
 
 ✅ Test your understanding of this code and the following code by running it in a browser console. Change the values of the currentMoney and laptopPrice variables to change the returned `console.log()`.
 
-
 ## Switch Statement
 
-The `switch` statement is used to perform different actions based on different conditions.Use the `switch` statement to select one of many code blocks to be executed.
+The `switch` statement is used to perform different actions based on different conditions. Use the `switch` statement to select one of many code blocks to be executed.
 
 ```javascript
-switch(expression) {
+switch (expression) {
   case x:
     // code block
     break;
@@ -95,7 +96,7 @@ switch(expression) {
     // code block
     break;
   default:
-    // code block
+  // code block
 }
 ```
 
@@ -104,21 +105,20 @@ switch(expression) {
 let a = 2;
 
 switch (a) {
-
-    case 1:
-        a = 'one';
-        break;
-    case 2:
-        a = 'two';
-        break;
-    default:
-        a = 'not found';
-        break;
+  case 1:
+    a = "one";
+    break;
+  case 2:
+    a = "two";
+    break;
+  default:
+    a = "not found";
+    break;
 }
 console.log(`The value is ${a}`);
 ```
-✅ Test your understanding of this code and the following code by running it in a browser console. Change the values of the varaiable a to change the returned `console.log()`.
 
+✅ Test your understanding of this code and the following code by running it in a browser console. Change the values of the varaiable a to change the returned `console.log()`.
 
 ## Logical Operators and Booleans
 
@@ -137,15 +137,14 @@ Logical operators can be used to form conditions in if..else statements.
 ```javascript
 let currentMoney;
 let laptopPrice;
-let laptopDiscountPrice = laptopPrice - (laptopPrice * .20) //Laptop price at 20 percent off
+let laptopDiscountPrice = laptopPrice - laptopPrice * 0.2; //Laptop price at 20 percent off
 
-if (currentMoney >= laptopPrice || currentMoney >= laptopDiscountPrice){
-    //Condition is true. Code in this block will run.
-    console.log("Getting a new laptop!");
-}
-else {
-    //Condition is true. Code in this block will run.
-    console.log("Can't afford a new laptop, yet!");
+if (currentMoney >= laptopPrice || currentMoney >= laptopDiscountPrice) {
+  //Condition is true. Code in this block will run.
+  console.log("Getting a new laptop!");
+} else {
+  //Condition is true. Code in this block will run.
+  console.log("Can't afford a new laptop, yet!");
 }
 ```
 
@@ -173,17 +172,18 @@ Below is a more tangible example:
 
 ```javascript
 let firstNumber = 20;
-let secondNumber = 10
-let biggestNumber = firstNumber > secondNumber ? firstNumber: secondNumber;
+let secondNumber = 10;
+let biggestNumber = firstNumber > secondNumber ? firstNumber : secondNumber;
 ```
 
 ✅ Take a minute to read this code a few times. Do you understand how these operators are working?
 
-The above states that 
-- if `firstNumber` is larger than `secondNumber` 
-- then assign `firstNumber` to `biggestNumber` 
-- else assign `secondNumber`. 
-  
+The above states that
+
+- if `firstNumber` is larger than `secondNumber`
+- then assign `firstNumber` to `biggestNumber`
+- else assign `secondNumber`.
+
 The ternary expression is just a compact way of writing the code below:
 
 ```javascript
@@ -202,7 +202,9 @@ if (firstNumber > secondNumber) {
 Create a program that is written first with logical operators, and then rewrite it using a ternary expression. What's your preferred syntax?
 
 ---
+
 ## Post-Lecture Quiz
+
 [Post-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/12)
 
 ## Review & Self Study


### PR DESCRIPTION
# Description

Working through the JavaScript section, specifically in "making-decisions", and noticed a missing space in the README.md file between sentences. 

Fixes # (issue)

Added the missing space in the "making-decisions" README.md file.

## Type of change

- This change requires a documentation update - fixed grammatical error in documentation README