### PR TITLE
Fixed Issues #1205 and #1184, wrong picture  for translated pages.

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -2,7 +2,7 @@
 
 This lesson covers the basics of programming languages. The topics covered here apply to most modern programming languages today. In the 'Tools of the Trade' section, you'll learn about useful software that helps you as a developer.
 
-![Intro Programming](../../sketchnotes/webdev101-programming.png)
+![Intro Programming](/sketchnotes/webdev101-programming.png)
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz


### PR DESCRIPTION

# Description

Changed the relative image path Link to Absolute image path link.

Fixes Issues #1205 and #1184, wrong picture for translated pages.

## Type of change

- [DONE] Bug fix (non-breaking change which fixes an issue)