### PR TITLE
Change link text

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -115,12 +115,12 @@ Developers rely on editors for a few additional reasons:
   - [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
   - [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)
   - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-- [Atom](https://atom.io/)
+- [Atom (discontinued)](https://atom.io/)
   - [spell-check](https://atom.io/packages/spell-check)
   - [teletype](https://atom.io/packages/teletype)
   - [atom-beautify](https://atom.io/packages/atom-beautify)
   
-- [www.sublimetext](https://www.sublimetext.com/)
+- [Sublime Text](https://www.sublimetext.com/)
   - [emmet](https://emmet.io/)
   - [SublimeLinter](http://www.sublimelinter.com/en/stable/)
 


### PR DESCRIPTION
- Changes the link text for Sublime text from "www.sublimetext" to "Sublime Text"
- Changes the link text for Atom from "Atom" to "Atom (discontinued)"

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes #1260  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update