### PR TITLE
Update azure-static-web-apps-ashy-river-0debb7803.yml

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-river-0debb7803.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-river-0debb7803.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   build_and_deploy_job:
+    permissions:
+      actions: write
+      checks: none
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job


### PR DESCRIPTION
https://docs.opensource.microsoft.com/github/apps/permission-changes/

Starting February 1, 2024 the default permission for the GITHUB_TOKEN will change from Read/Write to Read-only for all our Open Source GitHub orgs. This is a breaking change to many workflows.