### PR TITLE
Update README.md: Correct link text for Sublime Text and mention Atom deprecation

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -115,7 +115,7 @@ Developers rely on editors for a few additional reasons:
   - [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
   - [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)
   - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-- [Atom](https://atom.io/)
+- [Atom (Deprecated) Note: Atom has been deprecated, and users are encouraged to transition to alternative editors.](https://atom.io/)
   - [spell-check](https://atom.io/packages/spell-check)
   - [teletype](https://atom.io/packages/teletype)
   - [atom-beautify](https://atom.io/packages/atom-beautify)

--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -120,7 +120,7 @@ Developers rely on editors for a few additional reasons:
   - [teletype](https://atom.io/packages/teletype)
   - [atom-beautify](https://atom.io/packages/atom-beautify)
   
-- [www.sublimetext](https://www.sublimetext.com/)
+- [SublimeTextWebsite](https://www.sublimetext.com/)
   - [emmet](https://emmet.io/)
   - [SublimeLinter](http://www.sublimelinter.com/en/stable/)
 


### PR DESCRIPTION
# Description

Hello,

This is my first contribution to this project. I've made some updates to the README.md file to improve clarity and provide important information to users.

Changes Made #1261 (issue)

## Typo's

- [ ]Corrected the link text for Sublime Text to display as "SublimeTextWebsite" instead of "www.sublimetext".
- [ ]Added a note indicating that Atom has been deprecated and users are encouraged to transition to alternative editors.
- [ ] This change requires a documentation update