### PR TITLE
Link text for Sublime text has been fixed.

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -120,7 +120,7 @@ Developers rely on editors for a few additional reasons:
   - [teletype](https://atom.io/packages/teletype)
   - [atom-beautify](https://atom.io/packages/atom-beautify)
   
-- [www.sublimetext](https://www.sublimetext.com/)
+- [Sublimetext](https://www.sublimetext.com/)
   - [emmet](https://emmet.io/)
   - [SublimeLinter](http://www.sublimelinter.com/en/stable/)
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
Regarding this issue:

Incorrect link text #1260

Fixes # (issue)
Fixed the issue of link showing wrong description of "www.sublimetext" to Sublime text.
I have changed the incorrect spelling in the Readme.md file. The link text was starting with www instead of just Sublimetext.
I have removed www. from the link text.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
