### PR TITLE
Fix: broken pre-lecture quiz link with placeholder

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -3,10 +3,12 @@
 This lesson covers the basics of programming languages. The topics covered here apply to most modern programming languages today. In the 'Tools of the Trade' section, you'll learn about useful software that helps you as a developer.
 
 ![Intro Programming](../../sketchnotes/webdev101-programming.png)
+
 > Sketchnote by [Tomomi Imura](https://twitter.com/girlie_mac)
 
 ## Pre-Lecture Quiz
-[Pre-lecture quiz](https://forms.office.com/r/dru4TE0U9n?origin=lprLink)
+
+[Pre-lecture quiz - link to be updated]()
 
 ## Introduction
 
@@ -21,31 +23,33 @@ In this lesson, we'll cover:
 
 ## What is Programming?
 
-Programming (also known as coding) is the process of writing instructions for a device such as a computer or mobile device. We write these instructions with a programming language, which is then interpreted by the device. These sets of instructions may be referred to by various names, but *program*, *computer program*, *application (app)*, and *executable* are a few popular names.
+Programming (also known as coding) is the process of writing instructions for a device such as a computer or mobile device. We write these instructions with a programming language, which is then interpreted by the device. These sets of instructions may be referred to by various names, but _program_, _computer program_, _application (app)_, and _executable_ are a few popular names.
 
-A *program* can be anything that is written with code; websites, games, and phone apps are programs. While it's possible to create a program without writing code, the underlying logic is interpreted by the device and that logic was most likely written with code. A program that is *running* or *executing* code is carrying out instructions. The device that you're reading this lesson with is running a program to print it to your screen.
+A _program_ can be anything that is written with code; websites, games, and phone apps are programs. While it's possible to create a program without writing code, the underlying logic is interpreted by the device and that logic was most likely written with code. A program that is _running_ or _executing_ code is carrying out instructions. The device that you're reading this lesson with is running a program to print it to your screen.
 
 ✅ Do a little research: who is considered to have been the world's first computer programmer?
 
 ## Programming Languages
 
-Programming languages enable developers to write instructions for a device. Devices can only understand binary (1s and 0s), and for *most* developers that's not a very efficient way to communicate. Programming languages are the vehicle for communication between humans and computers.
+Programming languages enable developers to write instructions for a device. Devices can only understand binary (1s and 0s), and for _most_ developers that's not a very efficient way to communicate. Programming languages are the vehicle for communication between humans and computers.
 
 Programming languages come in different formats and may serve different purposes. For example, JavaScript is primarily used for web applications, while Bash is primarily used for operating systems.
 
-*Low level languages* typically require fewer steps than *high level languages* for a device to interpret instructions. However, what makes high level languages popular is their readability and support. JavaScript is considered a high level language.
+_Low level languages_ typically require fewer steps than _high level languages_ for a device to interpret instructions. However, what makes high level languages popular is their readability and support. JavaScript is considered a high level language.
 
 The following code illustrates the difference between a high level language with JavaScript and a low level language with ARM assembly code.
 
 ```javascript
-let number = 10
-let n1 = 0, n2 = 1, nextTerm;
+let number = 10;
+let n1 = 0,
+  n2 = 1,
+  nextTerm;
 
 for (let i = 1; i <= number; i++) {
-    console.log(n1);
-    nextTerm = n1 + n2;
-    n1 = n2;
-    n2 = nextTerm;
+  console.log(n1);
+  nextTerm = n1 + n2;
+  n1 = n2;
+  n2 = nextTerm;
 }
 ```
 
@@ -74,15 +78,15 @@ back add r0,r1
  end
 ```
 
-Believe it or not, *they're both doing the same thing*: printing a Fibonacci sequence up to 10.
+Believe it or not, _they're both doing the same thing_: printing a Fibonacci sequence up to 10.
 
 ✅ A Fibonacci sequence is [defined](https://en.wikipedia.org/wiki/Fibonacci_number) as a set of numbers such that each number is the sum of the two preceding ones, starting from 0 and 1. The first 10 numbers following the Fibonacci sequence are 0, 1, 1, 2, 3, 5, 8, 13, 21 and 34.
 
 ## Elements of a Program
 
-A single instruction in a program is called a *statement* and will usually have a character or line spacing that marks where the instruction ends, or *terminates*. How a program terminates varies with each language.
+A single instruction in a program is called a _statement_ and will usually have a character or line spacing that marks where the instruction ends, or _terminates_. How a program terminates varies with each language.
 
-Statements within a program may rely on data provided by a user or elsewhere to carry out instructions. Data can change how a program behaves, so programming languages come with a way to temporarily store data so that it can be used later. These are called *variables*. Variables are statements that instruct a device to save data in its memory. Variables in programs are similar to variables in algebra, where they have a unique name and their value may change over time.
+Statements within a program may rely on data provided by a user or elsewhere to carry out instructions. Data can change how a program behaves, so programming languages come with a way to temporarily store data so that it can be used later. These are called _variables_. Variables are statements that instruct a device to save data in its memory. Variables in programs are similar to variables in algebra, where they have a unique name and their value may change over time.
 
 There's a chance that some statements will not be executed by a device. This is usually by design when written by the developer or by accident when an unexpected error occurs. This type of control over an application makes it more robust and maintainable. Typically, these changes in control happen when certain conditions are met. A common statement used in modern programming to control how a program runs is the `if..else` statement.
 
@@ -104,10 +108,10 @@ One of the most crucial tools for software development is the editor. Editors ar
 
 Developers rely on editors for a few additional reasons:
 
-- *Debugging* helps uncover bugs and errors by stepping through the code, line by line. Some editors have debugging capabilities; they can be customized and added for specific programming languages.
-- *Syntax highlighting* adds colors and text formatting to code, making it easier to read. Most editors allow customized syntax highlighting.
-- *Extensions and Integrations* are specialized tools for developers, by developers. These tools weren't built into the base editor. For example, many developers document their code to explain how it works. They may install a spell check extension to help find typos within the documentation. Most extensions are intended for use within a specific editor, and most editors come with a way to search for available extensions.
-- *Customization* enables developers to create a unique development environment to suit their needs. Most editors are extremely customizable and may also allow developers to create custom extensions.
+- _Debugging_ helps uncover bugs and errors by stepping through the code, line by line. Some editors have debugging capabilities; they can be customized and added for specific programming languages.
+- _Syntax highlighting_ adds colors and text formatting to code, making it easier to read. Most editors allow customized syntax highlighting.
+- _Extensions and Integrations_ are specialized tools for developers, by developers. These tools weren't built into the base editor. For example, many developers document their code to explain how it works. They may install a spell check extension to help find typos within the documentation. Most extensions are intended for use within a specific editor, and most editors come with a way to search for available extensions.
+- _Customization_ enables developers to create a unique development environment to suit their needs. Most editors are extremely customizable and may also allow developers to create custom extensions.
 
 #### Popular Editors and Web Development Extensions
 
@@ -119,7 +123,6 @@ Developers rely on editors for a few additional reasons:
   - [spell-check](https://atom.io/packages/spell-check)
   - [teletype](https://atom.io/packages/teletype)
   - [atom-beautify](https://atom.io/packages/atom-beautify)
-  
 - [Sublimetext](https://www.sublimetext.com/)
   - [emmet](https://emmet.io/)
   - [SublimeLinter](http://www.sublimelinter.com/en/stable/)
@@ -128,7 +131,7 @@ Developers rely on editors for a few additional reasons:
 
 Another crucial tool is the browser. Web developers rely on the browser to see how their code runs on the web. It's also used to display the visual elements of a web page that are written in the editor, like HTML.
 
-Many browsers come with *developer tools* (DevTools) that contain a set of helpful features and information to help developers collect and capture important information about their application. For example: If a web page has errors, it's sometimes helpful to know when they occurred. DevTools in a browser can be configured to capture this information.
+Many browsers come with _developer tools_ (DevTools) that contain a set of helpful features and information to help developers collect and capture important information about their application. For example: If a web page has errors, it's sometimes helpful to know when they occurred. DevTools in a browser can be configured to capture this information.
 
 #### Popular Browsers and DevTools
 
@@ -144,7 +147,7 @@ Some developers prefer a less graphical view for their daily tasks and rely on t
 
 Options for the command line will differ based on the operating system you use.
 
-*💻 = comes preinstalled on the operating system.*
+_💻 = comes preinstalled on the operating system._
 
 #### Windows
 
@@ -152,7 +155,7 @@ Options for the command line will differ based on the operating system you use.
 - [Command Line](https://docs.microsoft.com/windows-server/administration/windows-commands/windows-commands/?WT.mc_id=academic-77807-sagibbon) (also known as CMD) 💻
 - [Windows Terminal](https://docs.microsoft.com/windows/terminal/?WT.mc_id=academic-77807-sagibbon)
 - [mintty](https://mintty.github.io/)
-  
+
 #### MacOS
 
 - [Terminal](https://support.apple.com/guide/terminal/open-or-quit-terminal-apd5265185d-f365-44cb-8b09-71a064a42125/mac) 💻
@@ -192,6 +195,7 @@ When a developer wants to learn something new, they'll most likely turn to docum
 Compare some programming languages. What are some of the unique traits of JavaScript vs. Java? How about COBOL vs. Go?
 
 ## Post-Lecture Quiz
+
 [Post-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
 
 ## Review & Self Study


### PR DESCRIPTION
# Description

Replaced the broken “Pre-lecture quiz” link in
1-getting-started-lessons/1-intro-to-programming-languages/README.md
with a placeholder:
[Pre-lecture quiz - link to be updated]()
The original link returned a “This form does not exist” error.

Fixes # (issue)
If there’s already an issue for this in the repo, put its number here, e.g. Fixes #42.
If no issue exists, you can leave it blank or write: