### PR TITLE
Fix broken post-lecture quiz link in Lesson 1 README (#1427)

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -192,7 +192,8 @@ When a developer wants to learn something new, they'll most likely turn to docum
 Compare some programming languages. What are some of the unique traits of JavaScript vs. Java? How about COBOL vs. Go?
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
+[Post-lecture quiz](../../quiz-app/lesson1-quiz.md)
+
 
 ## Review & Self Study
 


### PR DESCRIPTION
This PR resolves Issue #1427 by replacing the broken "Post-lecture quiz" link in the Lesson 1 README with a correct relative path to the quiz file inside the repository.

**Change made:**
- Updated Markdown link from the old Azure Static Web Apps quiz URL to `../../quiz-app/lesson1-quiz.md`.

This ensures the quiz link works even from within the local repo or when browsing on GitHub.
