### PR TITLE
Fix broken Azure quiz links in Lesson 1 README and translations (#1450)

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -192,7 +192,8 @@ When a developer wants to learn something new, they'll most likely turn to docum
 Compare some programming languages. What are some of the unique traits of JavaScript vs. Java? How about COBOL vs. Go?
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
+[Post-lecture quiz](../../quiz-app/lesson1-quiz.md)
+
 
 ## Review & Self Study
 


### PR DESCRIPTION
This PR fixes some of the broken links reported in Issue #1450 by updating outdated Azure Static Web Apps quiz URLs to point to the correct relative paths within the repository.

Changes made:

Replaced Azure Static Web Apps quiz URLs (which returned 404) with local relative links to the corresponding quiz markdown files in the quiz-app folder.

Applied changes to:

1-getting-started-lessons/1-intro-to-programming-languages/README.md


Reason:
The outdated Azure URLs are no longer valid. Using relative links ensures the quizzes are accessible both when browsing the repository on GitHub and when working locally.

Note for maintainers:
The same type of broken Azure quiz links appears in other lessons and translated files. I can fix those in similar small batches in follow‑up PRs if that would be helpful.