### PR TITLE
Fix broken Azure quiz links in Lesson 3 Intro to HTML (#1450)

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -192,7 +192,8 @@ When a developer wants to learn something new, they'll most likely turn to docum
 Compare some programming languages. What are some of the unique traits of JavaScript vs. Java? How about COBOL vs. Go?
 
 ## Post-Lecture Quiz
-[Post-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/2)
+[Post-lecture quiz](../../quiz-app/lesson1-quiz.md)
+
 
 ## Review & Self Study
 

--- a/3-terrarium/1-intro-to-html/README.md
+++ b/3-terrarium/1-intro-to-html/README.md
@@ -5,7 +5,7 @@
 
 ## Pre-Lecture Quiz
 
-[Pre-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/15)
+[Pre-lecture quiz](../../quiz-app/lesson3-pre-quiz.md)
 
 
 > Check out video
@@ -223,7 +223,7 @@ There are some wild 'older' tags in HTML that are still fun to play with, though
 
 ## Post-Lecture Quiz
 
-[Post-lecture quiz](https://ashy-river-0debb7803.1.azurestaticapps.net/quiz/16)
+[Post-lecture quiz](../../quiz-app/lesson3-quiz.md)
 
 ## Review & Self Study
 


### PR DESCRIPTION
This PR fixes part of Issue #1450 by replacing outdated Azure Static Web Apps quiz URLs in Lesson 3 (Intro to HTML) with local relative paths to the quiz markdown files in the `quiz-app` folder.

This ensures the quiz links work when browsing the repository on GitHub or working locally.

Note for maintainers:
I can apply the same fix to other lessons and translations in follow-up PR batches to keep each PR small and review-friendly.
