### PR TITLE
Fix missing alt text for accessibility compliance

### DIFF
--- a/3-terrarium/3-intro-to-DOM-and-closures/translations/README.it.md
+++ b/3-terrarium/3-intro-to-DOM-and-closures/translations/README.it.md
@@ -191,7 +191,7 @@ Questa piccola funzione reimposta gli eventi `onpointerup` e `onpointermove` in 
 
 Ora tsdi è completato il progetto!
 
-🥇Congratulazioni! Il meraviglioso terrario è finito![](../images/terrarium-final.png)
+🥇Congratulazioni! Il meraviglioso terrario è finito!![Terrario completato con piante disposte artisticamente](../images/terrarium-final.png)
 
 ---
 

--- a/7-bank-project/2-forms/translations/README.es.md
+++ b/7-bank-project/2-forms/translations/README.es.md
@@ -122,7 +122,7 @@ Agregue las propiedades `action` y `method` al formulario de registro:
 
 Ahora intente registrar una nueva cuenta con su nombre. Después de hacer clic en el botón * Registrarse *, debería ver algo como esto:
 
-![](./images/form-post.png)
+![Captura de pantalla mostrando la respuesta del servidor después de enviar el formulario](./images/form-post.png)
 
 Si todo va bien, el servidor debe responder a su solicitud con una respuesta [JSON](https://www.json.org/json-en.html) que contenga los datos de la cuenta que se creó.
 

--- a/7-bank-project/2-forms/translations/README.ko.md
+++ b/7-bank-project/2-forms/translations/README.ko.md
@@ -121,7 +121,7 @@ curl http://localhost:5000/api
 
 이제 이름으로 새로운 계정을 가입합니다. *Register* 버튼을 클릭하면 다음과 같은 내용이 표시됩니다:
 
-![](.././images/form-post.png)
+![폼 제출 후 서버 응답을 보여주는 스크린샷](.././images/form-post.png)
 
 모든 것이 잘 되면, 서버에 생성된 계정 데이터가 포함되어 [JSON](https://www.json.org/json-en.html)으로 응답해야 합니다.
 

--- a/7-bank-project/4-state-management/translations/README.es.md
+++ b/7-bank-project/4-state-management/translations/README.es.md
@@ -43,7 +43,7 @@ La [gestión del estado](https://en.wikipedia.org/wiki/State_management) se trat
 
 Una vez que se haya ocupado de esto, es posible que cualquier otro problema que pueda tener ya esté solucionado o que sea más fácil de solucionar. Hay muchos enfoques posibles para resolver estos problemas, pero optaremos por una solución común que consiste en **centralizar los datos y las formas de cambiarlos**. Los flujos de datos serían así:
 
-![](./images/data-flow.png)
+![Diagrama de flujo de datos mostrando la arquitectura centralizada](./images/data-flow.png)
 
 > No cubriremos aquí la parte en la que los datos activan automáticamente la actualización de la vista, ya que está vinculada a conceptos más avanzados de [Programación reactiva](https://en.wikipedia.org/wiki/Reactive_programming). Es un buen tema de seguimiento si estás preparado para una inmersión profunda.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub forks](https://img.shields.io/github/forks/microsoft/Web-Dev-For-Beginners.svg?style=social&label=Fork&maxAge=2592000)](https://GitHub.com/microsoft/Web-Dev-For-Beginners/network/)
 [![GitHub stars](https://img.shields.io/github/stars/microsoft/Web-Dev-For-Beginners.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/microsoft/Web-Dev-For-Beginners/stargazers/)
 
-[![](https://dcbadge.vercel.app/api/server/ByRwuEEgH4)](https://discord.gg/zxKYvhSnVp?WT.mc_id=academic-000002-leestott)
+[![Discord](https://dcbadge.vercel.app/api/server/ByRwuEEgH4)](https://discord.gg/zxKYvhSnVp?WT.mc_id=academic-000002-leestott)
 
 [![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://open.vscode.dev/microsoft/Web-Dev-For-Beginners)
 


### PR DESCRIPTION
- Add descriptive alt text for Discord badge in main README
- Add alt text for data flow diagram in Spanish state management docs
- Add alt text for form POST screenshot in Spanish and Korean forms docs
- Add alt text for completed terrarium image in Italian tutorial
- Improves accessibility for screen reader users and WCAG compliance

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update