### PR TITLE
Fix link to new AI Assistant project in README :Fix: broken README link to AI Assistant project (09→9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ New Challenge added, look for "GitHub Copilot Agent Challenge 🚀" in most chap
 
 ### 📣 Announcement - _New Project to build using Generative AI_ 
 
-New AI Assistant project just added, check it out [project](./09-chat-project/README.md)
+New AI Assistant project just added, check it out [project](./9-chat-project/README.md)
 
 ### 📣 Announcement - _New Curriculum_ on Generative AI for JavaScript was just released
 


### PR DESCRIPTION
Fix broken link in the README Announcement for the new AI Assistant project.
Changed ./09-chat-project/README.md → ./9-chat-project/README.md.

Why: The directory is named 9-chat-project (no leading zero), so the old path 404s.
Notes: The Lessons table already points to ./9-chat-project/README.md; this change just aligns the Announcement link.

Fixes #1554.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

This change requires a documentation update
Impact / Risk
Docs-only change; no code touched.

How I tested
Clicked the updated link in my fork’s README → it resolves to 9-chat-project/README.md.