### PR TITLE
docs(README): fix “Open in Visual Studio Code” badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow these steps to get started using these resources:
 
 **If you wish to have additional translations languages supported are listed [here](https://github.com/Azure/co-op-translator/blob/main/getting_started/supported-languages.md)**
 
-[![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://open.vscode.dev/microsoft/Web-Dev-For-Beginners)
+[![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://vscode.dev/github/microsoft/Web-Dev-For-Beginners)
 
 #### 🧑‍🎓 _Are you a student?_
 


### PR DESCRIPTION
Change README badge target from `open.vscode.dev` to `vscode.dev/github/...` so it opens in VS Code for the Web correctly.

Fixes #1587.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update