### PR TITLE
Fix two broken links of AI Asistant Project (09 -> 9) and genai-js-course in tw translation README.md 

### DIFF
--- a/translations/tw/README.md
+++ b/translations/tw/README.md
@@ -71,7 +71,7 @@ CO_OP_TRANSLATOR_METADATA:
 - 文本及圖像應用程式生成
 - 搜索應用程式
 
-造訪 [https://aka.ms/genai-js-course](../../[https:/aka.ms/genai-js-course) 開始學習！
+造訪 [https://aka.ms/genai-js-course](https://aka.ms/genai-js-course) 開始學習！
 
 ## 🌱 開始使用
 


### PR DESCRIPTION
# Description

Find two broken links in tw README.md. 
1. AI Asistant Project link (09 -> 9)
2. genai-js-course redirect link 

Fixes doc issue like #1554 ...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update