### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-river-0debb7803.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-river-0debb7803.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Build And Deploy

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v6
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has not seen any action for a while! Closing for now, but it can be reopened at a later date.'


### PR DESCRIPTION
# Description

This PR updates outdated GitHub Action versions to ensure compatibility and stability. The changes include updating `actions/checkout` from version v3 to v6 in two workflows, updating `actions/checkout` from v4 to v6 in another workflow, updating `actions/stale` from v6 to v10, and updating `peter-evans/create-issue-from-file` from v5 to v6.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update