### PR TITLE
[Docs] Fix malformed markdown link to Generative AI curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Each lesson includes an assignment to complete, a knowledge check and a challeng
 - Text and image app generation
 - Search apps
 
-Visit [https://aka.ms/genai-js-course]([https://aka.ms/genai-js-course) to get started!
+Visit [https://aka.ms/genai-js-course](https://aka.ms/genai-js-course) to get started!
 
 
 


### PR DESCRIPTION
# Description

Fixes a malformed markdown link in the main README that prevents users from clicking through to the Generative AI for JavaScript course. This was a copy-paste error that introduced an extra `[` character in the markdown link syntax.

## The Bug
The link had an extra opening bracket `[` before `https`, breaking the markdown link functionality:

**Before (broken):**
Visit [https://aka.ms/genai-js-course]([https://aka.ms/genai-js-course) to get started!

**After (fixed):**
Visit [https://aka.ms/genai-js-course](https://aka.ms/genai-js-course) to get started!

This fix ensures that users can successfully click the link to access the Generative AI curriculum.

Fixes #1677

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Notes

- **Files changed**: 1 (README.md)
- **Lines changed**: 1
- **Impact**: Low risk, high value user experience improvement
- **Branch**: `docs/fix-genai-js-link`