### PR TITLE
fix: remove broken KDE docs link

### DIFF
--- a/1-getting-started-lessons/1-intro-to-programming-languages/README.md
+++ b/1-getting-started-lessons/1-intro-to-programming-languages/README.md
@@ -665,7 +665,7 @@ npx vite
 
 **Linux:**
 - **[Bash](https://www.gnu.org/software/bash/)** 💻 - Standard Linux shell
-- **[KDE Konsole](https://docs.kde.org/trunk5/en/konsole/konsole/index.html)** - Advanced terminal emulator
+- **KDE Konsole** – Advanced terminal emulator
 
 > 💻 = Pre-installed on the operating system
 


### PR DESCRIPTION
Fixes #1797

Removed a broken link (404 error) from the documentation.