### PR TITLE
Prevent runtime errors in typing game when quotes list in empty

### DIFF
--- a/4-typing-game/solution/index.js
+++ b/4-typing-game/solution/index.js
@@ -30,7 +30,13 @@ const messages = {
 };
 
 // Utility: pick random quote
-const getRandomQuote = () => quotes[Math.floor(Math.random() * quotes.length)];
+const getRandomQuote = () => {
+  if (!Array.isArray(quotes) || quotes.length === 0) {
+    return "";
+  }
+  const index= MAth.floor(Math.random() * quotes.length);
+  return quotes[index];
+};
 
 // Utility: render quote as spans
 const renderQuote = (quote) => {


### PR DESCRIPTION
# Description

This pull request improves the robustness of the typing game by adding a defensive check in the 'getRandonQuote' utility function.

When the quotes list is empty or invalid, the previous implementation could return 'undefined', leading to runtime errors. This change ensures safe handling of such edge cases.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
