### PR TITLE
fix: Fix quiz locale matching for zh-CN

### DIFF
--- a/quiz-app/src/components/QuizComponent.vue
+++ b/quiz-app/src/components/QuizComponent.vue
@@ -18,6 +18,7 @@
 
 </style>
 <template>
+  <div>
     <div class="card">
         Back to <router-link to="/">Quizzes</router-link>
     </div>
@@ -59,9 +60,14 @@
         </div>
       </div>
     </div>
+  </div>
   </template>
   
   <script>
+
+  function normalizeLocale(locale) {
+    return (locale || "").toLowerCase().replace("-", "_");
+  }
 
   function getFileByLocale(locale) {
     // loop keys in messages, if key is the start of locale, return that file
@@ -71,8 +77,9 @@
         quizzes: [],
         title: "Default Quiz",
     };
+    const normalizedLocale = normalizeLocale(locale);
     for (let key in messages) {
-      if (locale.startsWith(key)) {
+      if (normalizedLocale.startsWith(key)) {
         file = messages[key];
         break;
       }
@@ -94,8 +101,8 @@
         complete: false,
         error: false,
         route: "",
-        locale: "",
-        file: getFileByLocale(locale),
+        locale: this.$route.query.loc || locale,
+        file: getFileByLocale(this.$route.query.loc || locale),
       };
     },
     computed: {
@@ -105,7 +112,6 @@
     },
     created() {
       this.route = this.$route.params.id;
-      this.locale = this.$route.query.loc;
     },
     methods: {
       handleAnswerClick(isCorrect) {

--- a/quiz-app/src/components/QuizzesComponent.vue
+++ b/quiz-app/src/components/QuizzesComponent.vue
@@ -8,21 +8,29 @@
 
 </style>
 <template>
-    <div class="question" v-for="q in questions" :key="q.id" >
+  <div>
+    <div
+      class="question"
+      v-for="q in questions"
+      :key="q.id"
+    >
       <router-link
-        
-        :key="q.id"
         :to="`quiz/${q.id}`"
         class="link"
       >
         {{ q.title }}
       </router-link>
     </div>
+  </div>
   </template>
   
   <script>
   import messages from "@/assets/translations";
   
+  function normalizeLocale(locale) {
+    return (locale || "").toLowerCase().replace("-", "_");
+  }
+
   function getFileByLocale(locale) {
     // loop keys in messages, if key is the start of locale, return that file
     let file = {
@@ -31,8 +39,9 @@
         quizzes: [],
         title: "Default Quiz",
     };
+    const normalizedLocale = normalizeLocale(locale);
     for (let key in messages) {
-      if (locale.startsWith(key)) {
+      if (normalizedLocale.startsWith(key)) {
         file = messages[key];
         break;
       }
@@ -46,7 +55,7 @@
     name: "QuizzesComponent",
     data() {
       return {
-        file: getFileByLocale(locale),
+        file: getFileByLocale(this.$route.query.loc || locale),
       };
     },
     computed: {


### PR DESCRIPTION
## Description

This fixes Simplified Chinese quiz loading in the quiz app.

The app has a Simplified Chinese translation key named `zh_cn`, but browsers usually report the locale as `zh-CN`. Because the app compared the raw locale with `locale.startsWith(key)`, `zh-CN` did not match `zh_cn`.

This change normalizes locale values by lowercasing and replacing `-` with `_`. It also lets the `loc` query parameter choose the quiz translation before the quiz file is selected.

Fixes no linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tested

- `npm run build`
- `http://localhost:5173/?loc=zh_cn` shows the Chinese quiz list
- `http://localhost:5173/quiz/1?loc=zh_cn` shows Lesson 1 pre-lecture quiz in Chinese
- Clicking the correct first answer advances to the second question