### PR TITLE
docs: fix past participle 'showed' to 'shown' in drawing-to-canvas README

### DIFF
--- a/6-space-game/2-drawing-to-canvas/README.md
+++ b/6-space-game/2-drawing-to-canvas/README.md
@@ -153,7 +153,7 @@ ctx.fillRect(0, 0, 200, 200); // x, y, width, height
 
 You can draw all sorts of things with the Canvas API like:
 
-- **Geometrical shapes**, we've already showed how to draw a rectangle, but there is much more you can draw.
+- **Geometrical shapes**, we've already shown how to draw a rectangle, but there is much more you can draw.
 - **Text**, you can draw a text with any font and color you wish.
 - **Images**, you can draw an image based off of an image asset like a .jpg or .png for example.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `6-space-game/2-drawing-to-canvas/README.md` (line 156).

## Problem

Past participle of 'show' is 'shown', not 'showed'. Should be 'we've already shown'.

The problematic text:

```markdown
we've already showed how to draw a rectangle
```

## Fix

Replaced with:

```markdown
we've already shown how to draw a rectangle
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text