### PR TITLE
docs: fix CO2 typo (C02 with zero) in browser extension solution README

### DIFF
--- a/5-browser-extension/solution/README.md
+++ b/5-browser-extension/solution/README.md
@@ -1,6 +1,6 @@
 # Carbon Trigger Browser Extension: Completed Code
 
-Using tmrow's C02 Signal API to track electricity usage, build a browser extension so that you can have a reminder right in your browser about how heavy your region's electricity usage is. Using this extension ad hoc will help you to make judgement calls on your activities based on this information.
+Using tmrow's CO2 Signal API to track electricity usage, build a browser extension so that you can have a reminder right in your browser about how heavy your region's electricity usage is. Using this extension ad hoc will help you to make judgement calls on your activities based on this information.
 
 ![extension screenshot](../extension-screenshot.png)
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `5-browser-extension/solution/README.md` (line 3).

## Problem

Typo: 'C02' uses digit zero instead of letter O. The correct chemical formula for carbon dioxide is 'CO2'.

The problematic text:

```markdown
Using tmrow's C02 Signal API
```

## Fix

Replaced with:

```markdown
Using tmrow's CO2 Signal API
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text