### PR TITLE
docs: fix doubled 'the' and grammar in ai-framework-project README

### DIFF
--- a/10-ai-framework-project/README.md
+++ b/10-ai-framework-project/README.md
@@ -539,7 +539,7 @@ if(res.tool_calls):
 print("CONTENT: ",res.content)
 ```
 
-Now that we call `invoke` on this new llm, that has tools, we maybe the the property `tool_calls` populated. If so, any identified tools has a `name` and `args` property that identifies what tool should be called and with arguments. The full code looks like so:
+Now that we call `invoke` on this new llm, that has tools, we may see the `tool_calls` property populated. If so, any identified tools has a `name` and `args` property that identifies what tool should be called and with arguments. The full code looks like so:
 
 ```python
 from langchain_core.messages import HumanMessage, SystemMessage


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `10-ai-framework-project/README.md` (line 542).

## Problem

Contains doubled 'the' ('the the') and awkward grammar. Should be 'we may see the `tool_calls` property populated'.

The problematic text:

```markdown
we maybe the the property `tool_calls` populated
```

## Fix

Replaced with:

```markdown
we may see the `tool_calls` property populated
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text